### PR TITLE
Fix duplicate students.show route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -53,8 +53,6 @@ Route::middleware(['auth', 'role:student'])->group(function () {
     Route::post('/student-profile', [StudentProfileController::class, 'update'])->name('student.profile.update');
 });
 
-// Public routes for viewing student profiles
-Route::get('/students/{student}', [StudentProfileController::class, 'show'])->name('students.show');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
## Summary
- remove duplicate `students.show` route that used `StudentProfileController`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684775531144832dbe030a9e04377c29