### PR TITLE
Fix profile picture preview update

### DIFF
--- a/resources/js/Pages/Teachers/Profile/Edit.jsx
+++ b/resources/js/Pages/Teachers/Profile/Edit.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import TeacherLayout from "@/Layouts/TeacherLayout";
 import { Head, useForm } from "@inertiajs/react";
 import InputError from '@/Components/InputError';
@@ -11,6 +11,10 @@ export default function Edit({ auth, profile, timezones }) {
     const [selectedImage, setSelectedImage] = useState(
         profile.profile_picture ? `/storage/${profile.profile_picture}` : null
     );
+
+    useEffect(() => {
+        setSelectedImage(profile.profile_picture ? `/storage/${profile.profile_picture}` : null);
+    }, [profile.profile_picture]);
     
     const { data, setData, post, processing, errors, recentlySuccessful } = useForm({
         bio: profile.bio || '',


### PR DESCRIPTION
## Summary
- reload picture preview after saving profile changes

## Testing
- `npm run build --silent`
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847795799d8832d9042abd2538ef30f